### PR TITLE
Exclude test fixture data from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["HTML", "entities", "character", "escape"]
 edition = "2015"
 rust-version = "1.13"
 
+exclude = ["tests/entities.json"]
+
 [dependencies]
 
 [dev-dependencies]


### PR DESCRIPTION
The entities.json file isn't used by consumers of the crate, so since it's relatively large, exclude it from the package.